### PR TITLE
fixed redirect issue

### DIFF
--- a/app/code/community/Sandfox/RemovePaypalExpressReviewStep/Model/Observer.php
+++ b/app/code/community/Sandfox/RemovePaypalExpressReviewStep/Model/Observer.php
@@ -6,4 +6,11 @@ class Sandfox_RemovePaypalExpressReviewStep_Model_Observer
 	{
 		Mage::app()->getResponse()->setRedirect(Mage::getUrl('*/*/placeOrder'));
 	}
+
+	public function controllerActionPredispatchPaypalExpressPlaceOrder(Varien_Event_Observer $observer)
+	{
+		$requiredAgreements = Mage::helper('checkout')->getRequiredAgreementIds();
+		$postedAgreements = array_fill_keys($requiredAgreements, 1);
+		Mage::app()->getRequest()->setPost('agreement', $postedAgreements);
+	}
 }

--- a/app/code/community/Sandfox/RemovePaypalExpressReviewStep/etc/config.xml
+++ b/app/code/community/Sandfox/RemovePaypalExpressReviewStep/etc/config.xml
@@ -26,6 +26,15 @@
                     </sandfox_removepaypalexpressreviewstep>
                 </observers>
             </controller_action_predispatch_paypal_express_review>
+            <controller_action_predispatch_paypal_express_placeOrder>
+                <observers>
+                    <sandfox_removepaypalexpressreviewstep>
+                        <type>singleton</type>
+                        <class>sandfox_removepaypalexpressreviewstep/observer</class>
+                        <method>controllerActionPredispatchPaypalExpressPlaceOrder</method>
+                    </sandfox_removepaypalexpressreviewstep>
+                </observers>
+            </controller_action_predispatch_paypal_express_placeOrder>
         </events>
     </global>
 </config>


### PR DESCRIPTION
If you have a look at `Mage_Paypal_Controller_Express_Abstract::placeOrderAction`, you see that there will be a redirect to the `reviewAction` if there are required agreements which have not been accepted. When using this extension, the `reviewAction` is again redirected to the `placeOrderAction`. This results in an infinite loop as discussed in #2. This PR fixes this issue.

It alters the `POST` params and pretends that all agreements have been accepted. This should be okay as long as you use PayPal express as a normal payment method (and not from the cart or product detail page; but in this case, this extension does not make sense anyway).
